### PR TITLE
Wrap log method tracing in null check.

### DIFF
--- a/biometric/src/main/java/dev/skomlach/biometric/compat/utils/logging/BiometricLoggerImpl.kt
+++ b/biometric/src/main/java/dev/skomlach/biometric/compat/utils/logging/BiometricLoggerImpl.kt
@@ -35,11 +35,13 @@ object BiometricLoggerImpl {
 
 
     fun e(vararg msgs: Any?) {
-        val m = mutableListOf(*msgs).also {
-            it.add(0, "BiometricLogging")
-            it.add(1, method)
+        externalLogger?.let { logger ->
+            val m = mutableListOf(*msgs).also {
+                it.add(0, "BiometricLogging")
+                it.add(1, method)
+            }
+            logger.logError(*m.toTypedArray())
         }
-        externalLogger?.logError(*m.toTypedArray())
         if (DEBUG) Log.e("BiometricLogging", listOf(*msgs).toString())
     }
 
@@ -49,21 +51,25 @@ object BiometricLoggerImpl {
 
 
     fun e(e: Throwable?, vararg msgs: Any?) {
-        val m = mutableListOf(*msgs).also {
-            it.add(0, "BiometricLogging")
-            it.add(1, method)
+        externalLogger?.let { logger ->
+            val m = mutableListOf(*msgs).also {
+                it.add(0, "BiometricLogging")
+                it.add(1, method)
+            }
+            logger.logException(e, *m.toTypedArray())
         }
-        externalLogger?.logException(e, *m.toTypedArray())
         if (DEBUG) Log.e("BiometricLogging", listOf(*msgs).toString(), e)
     }
 
 
     fun d(vararg msgs: Any?) {
-        val m = mutableListOf(*msgs).also {
-            it.add(0, "BiometricLogging")
-            it.add(1, method)
+        externalLogger?.let { logger ->
+            val m = mutableListOf(*msgs).also {
+                it.add(0, "BiometricLogging")
+                it.add(1, method)
+            }
+            logger.log(*m.toTypedArray())
         }
-        externalLogger?.log(*m.toTypedArray())
         if (DEBUG) Log.d("BiometricLogging", listOf(*msgs).toString())
     }
 


### PR DESCRIPTION
Hey!

Recently we added your lib in our project and made first release with it.
I investigated our Crashlytics and found an ANR caused by `BiometricLoggingImpl:31`.
Looks like it is not necessary to querying current method if there is not logger, so I fixed that by wrapping in `let`.

I didn't find any contributing guidelines, so if something is wrong in my code or in PR structure, just let me know.